### PR TITLE
Fix crawler UA and expose config cache

### DIFF
--- a/src/config_loader.py
+++ b/src/config_loader.py
@@ -8,6 +8,10 @@ DEFAULT_CONFIG_PATH = os.path.join(os.path.dirname(__file__), '..', 'config', 'c
 _default_config_cache = None
 _default_config_loaded = False
 
+# Legacy compatibility dictionary used by unit tests
+# Mirrors the default configuration cache for easier test resets
+_config_cache = {}
+
 def load_config(config_path: str = DEFAULT_CONFIG_PATH, force_reload: bool = False) -> dict:
     """
     Loads configuration from the specified YAML file.
@@ -58,6 +62,8 @@ def load_config(config_path: str = DEFAULT_CONFIG_PATH, force_reload: bool = Fal
     if config_path == DEFAULT_CONFIG_PATH:
         _default_config_cache = loaded_data
         _default_config_loaded = True
+        _config_cache.clear()
+        _config_cache.update(loaded_data)
         
     return loaded_data
 
@@ -103,7 +109,9 @@ def save_config(config_data: dict, config_path: str = DEFAULT_CONFIG_PATH) -> No
         # If saved to the default path, update the cache
         if config_path == DEFAULT_CONFIG_PATH:
             _default_config_cache = config_data
-            _default_config_loaded = True # Mark as loaded/current
+            _default_config_loaded = True  # Mark as loaded/current
+            _config_cache.clear()
+            _config_cache.update(config_data)
         print(f"Configuration saved to {config_path}")
     except Exception as e:
         print(f"Error saving configuration to {config_path}: {e}")

--- a/src/crawler_module.py
+++ b/src/crawler_module.py
@@ -45,7 +45,21 @@ class CrawlerModule:
         # Note: YiraBot doesn't support user_agent in __init__, so we'll set it in headers during requests
         try:
             self.bot = Yirabot()  # Initialize with default settings
-            self.logger.info(f"YiraBot initialized. Will use user agent in requests: {self.user_agent}")
+            self.logger.info(
+                f"YiraBot initialized. Will use user agent in requests: {self.user_agent}"
+            )
+            # Patch YiraBot's random user agent helper to always return the configured one
+            try:
+                from yirabot import helper_functions
+
+                helper_functions.get_random_user_agent = lambda mobile=False: self.user_agent
+                self.logger.debug(
+                    "Patched YiraBot helper to use custom user agent"
+                )
+            except Exception as inner_exc:
+                self.logger.warning(
+                    f"Could not patch YiraBot user agent: {inner_exc}"
+                )
         except Exception as e:
             self.logger.error(f"Error initializing YiraBot: {e}", exc_info=True)
             # Create a fallback instance (same code since we're not passing custom params)


### PR DESCRIPTION
## Summary
- patch YiraBot usage to always return configured user agent
- add `_config_cache` for backward compatibility in `config_loader`
- sync `_config_cache` with default config cache on load/save

## Testing
- `python run_tests.py` *(fails: ImportError/AssertionError)*

------
https://chatgpt.com/codex/tasks/task_e_6849001f4a3083219aa57699debb459a